### PR TITLE
Feature/nsa 8787 support for new cdn

### DIFF
--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -182,7 +182,7 @@ stages:
                             inlineScript: |
                               
                               $FWTestAttempt = 1
-                              $FWTestMax = 10
+                              $FWTestMax = 30
                               
                               do {
                                   try {

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -147,7 +147,7 @@ stages:
                             workingDirectory: $(System.DefaultWorkingDirectory)
 
                         - task: AzureKeyVault@2
-                          displayName: Load environment [${{ env }}] secrets
+                          displayName: Load environment secrets
                           inputs:
                             azureSubscription: $(${{variables.ServConName}})
                             KeyVaultName: '$(keyVaultName)'

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -180,8 +180,8 @@ stages:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
                               $FWTestAttempt = 1
-                              $FWTestMax = 25
-                              Start-Sleep -Seconds 35
+                              $FWTestMax = 10
+                              Start-Sleep -Seconds 10
                               do {
                                   try {
                                       write-output "Removing files from storage account"

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -61,7 +61,7 @@ variables:
   - group: dsi-global
   - group: dsi-envs-list
   - name: tran
-    value: ${{ or(eq(parameters.tran, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
+    value: ${{ eq(parameters.tran, 'true') }}
   - name: dev
     value: ${{ or(eq(parameters.dev, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
   - name: test
@@ -203,7 +203,7 @@ stages:
                                   }
                                   catch {
                                       if ($FWTestAttempt -lt $FWTestMax) {
-                                          write-output "An error occurred during adding or removing files in storage account. $FWTestAttempt/$FWTestMax"
+                                          write-output "An error occurred during adding or removing files in storage account - attempt $FWTestAttempt/$FWTestMax - retrying..."
                                           $FWTestAttempt++
                                           Start-Sleep -Seconds 10
                                       }
@@ -216,7 +216,7 @@ stages:
 
                               if($ShdResourceGroupName -NotLike '*neu*'){
                                 $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
-                                write-output "Purging CDN"
+                                write-output "Purging CDN - this will take several minutes"
                                 az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --verbose
 
                                 if($env:newCdnV){

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -146,6 +146,14 @@ stages:
                             arguments: "-keyVault $(keyVaultName) -keyVaultRg $(keyVaultResourceGroupName) -WhiteListIP $True -NotSelfHost $True"
                             workingDirectory: $(System.DefaultWorkingDirectory)
 
+                        - task: AzureKeyVault@2
+                          displayName: Load environment [${{ env }}] secrets
+                          inputs:
+                            azureSubscription: $(${{variables.ServConName}})
+                            KeyVaultName: '$(keyVaultName)'
+                            SecretsFilter: '*'
+                            RunAsPreJob: false
+                        
                         - task: AzureCLI@2
                           displayName: "Enable Access to Storage Account"
                           condition: ${{not(parameters.shaUse)}}
@@ -192,7 +200,9 @@ stages:
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
-                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --content-paths /* --debug #--domains www.contoso.com
+                                        cdnHostNameStripped=${cdnHostName#https://}
+                                        
+                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $(cdnHostNameStripped) --content-paths /*
 
                                         if($env:newCdnV){
                                           $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -179,50 +179,51 @@ stages:
                             ${{ if not(parameters.shaUse) }}:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
-                              #$ErrorActionPreference = "Stop"
-                              # write-output "Waiting for FW rule to apply."
+                              $FWTestAttempt = 1
+                              $FWTestMax = 25
+                              Start-Sleep -Seconds 35
+                              do {
+                                  try {
+                                      write-output "Removing files from storage account"
 
-                              # $FWTestAttempt = 1
-                              # $FWTestMax = 25
-                              # Start-Sleep -Seconds 35
-                              # do {
-                              #     try {
-                                      # az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
-                                      # if ($? -eq $false) {
-                                      #   throw 'Failed to  delete-batch on storage account'
-                                      # }
-                                      # az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
-                                      # if ($? -eq $false) {
-                                      #   throw 'Failed to  upload-batch on storage account'
-                                      # }
-
-                                      # write-output "Storage is now accessible & and data is uploaded"
-
-                                      if($ShdResourceGroupName -NotLike '*neu*'){
-                                        $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
-                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --verbose
-
-                                        # if($env:newCdnV){
-                                        #   $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
-                                        #   $cdnAssetsVersion = [decimal]$cdnAssetsVersion
-                                        #   $newCdnAssetsVersion = $cdnAssetsVersion+0.1
-                                        #   az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
-                                        # }
+                                      az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
+                                      if ($? -eq $false) {
+                                        throw 'Failed to  delete-batch on storage account'
+                                      }
+                                      
+                                      write-output "Uploading files to storage account"
+                                      az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
+                                      if ($? -eq $false) {
+                                        throw 'Failed to  upload-batch on storage account'
                                       }
 
-                              #         exit 0
-                              #     }
-                              #     catch {
-                              #         if ($FWTestAttempt -lt $FWTestMax) {
-                              #             write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
-                              #             $FWTestAttempt++
-                              #             Start-Sleep -Seconds 20
-                              #         }
-                              #         else {
-                              #             Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
-                              #         }
-                              #     }
-                              # } while ($FWTestAttempt -lt $FWTestMax)
+                                      exit 0
+                                  }
+                                  catch {
+                                      if ($FWTestAttempt -lt $FWTestMax) {
+                                          write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
+                                          $FWTestAttempt++
+                                          Start-Sleep -Seconds 20
+                                      }
+                                      else {
+                                          Write-Error "An error occurred during adding or removing files in storage account. $FWTestAttempt/$FWTestMax."
+                                      }
+                                  }
+                              } while ($FWTestAttempt -lt $FWTestMax)
+
+                              if($ShdResourceGroupName -NotLike '*neu*'){
+                                $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
+                                write-output "Purging CDN"
+                                az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --verbose
+
+                                if($env:newCdnV){
+                                  write-output "Incrementing keyvault value cdnAssetsVersion by 0.1"
+                                  $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
+                                  $cdnAssetsVersion = [decimal]$cdnAssetsVersion
+                                  $newCdnAssetsVersion = $cdnAssetsVersion+0.1
+                                  az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
+                                }
+                              }
 
                         - task: AzureCLI@2
                           displayName: Remove White-list of storage

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -197,7 +197,7 @@ stages:
                                         throw 'Failed to  upload-batch on storage account'
                                       }
 
-                                      exit 0
+                                      break
                                   }
                                   catch {
                                       if ($FWTestAttempt -lt $FWTestMax) {

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -179,54 +179,50 @@ stages:
                             ${{ if not(parameters.shaUse) }}:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
-                              #$ErrorActionPreference = "Stop"
-                              # write-output "Waiting for FW rule to apply."
+                              $ErrorActionPreference = "Stop"
+                              write-output "Waiting for FW rule to apply."
 
-                              # $FWTestAttempt = 1
-                              # $FWTestMax = 25
-                              # Start-Sleep -Seconds 35
-                              # do {
-                              #     try {
-                                      # az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
-                                      # if ($? -eq $false) {
-                                      #   throw 'Failed to  delete-batch on storage account'
-                                      # }
-                                      # az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
-                                      # if ($? -eq $false) {
-                                      #   throw 'Failed to  upload-batch on storage account'
-                                      # }
-
-                                      # write-output "Storage is now accessible & and data is uploaded"
-
-                                      if($ShdResourceGroupName -NotLike '*neu*'){
-                                        #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
-                                        $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
-                                        echo "The value of cdnHostName is: $env:cdnHostName"
-                                        echo "The value of cdnHostNameStripped is: $cdnHostNameStripped"
-                                        
-                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --debug
-
-                                        # if($env:newCdnV){
-                                        #   $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
-                                        #   $cdnAssetsVersion = [decimal]$cdnAssetsVersion
-                                        #   $newCdnAssetsVersion = $cdnAssetsVersion+0.1
-                                        #   az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
-                                        # }
+                              $FWTestAttempt = 1
+                              $FWTestMax = 25
+                              Start-Sleep -Seconds 35
+                              do {
+                                  try {
+                                      az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
+                                      if ($? -eq $false) {
+                                        throw 'Failed to  delete-batch on storage account'
+                                      }
+                                      az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
+                                      if ($? -eq $false) {
+                                        throw 'Failed to  upload-batch on storage account'
                                       }
 
-                              #         exit 0
-                              #     }
-                              #     catch {
-                              #         if ($FWTestAttempt -lt $FWTestMax) {
-                              #             write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
-                              #             $FWTestAttempt++
-                              #             Start-Sleep -Seconds 20
-                              #         }
-                              #         else {
-                              #             Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
-                              #         }
-                              #     }
-                              # } while ($FWTestAttempt -lt $FWTestMax)
+                                      write-output "Storage is now accessible & and data is uploaded"
+
+                                      if($ShdResourceGroupName -NotLike '*neu*'){
+                                        $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
+                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --verbose
+
+                                        if($env:newCdnV){
+                                          $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
+                                          $cdnAssetsVersion = [decimal]$cdnAssetsVersion
+                                          $newCdnAssetsVersion = $cdnAssetsVersion+0.1
+                                          az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
+                                        }
+                                      }
+
+                                      exit 0
+                                  }
+                                  catch {
+                                      if ($FWTestAttempt -lt $FWTestMax) {
+                                          write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
+                                          $FWTestAttempt++
+                                          Start-Sleep -Seconds 20
+                                      }
+                                      else {
+                                          Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
+                                      }
+                                  }
+                              } while ($FWTestAttempt -lt $FWTestMax)
 
                         - task: AzureCLI@2
                           displayName: Remove White-list of storage

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -186,30 +186,31 @@ stages:
                               Start-Sleep -Seconds 35
                               do {
                                   try {
-                                      az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
-                                      if ($? -eq $false) {
-                                        throw 'Failed to  delete-batch on storage account'
-                                      }
-                                      az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
-                                      if ($? -eq $false) {
-                                        throw 'Failed to  upload-batch on storage account'
-                                      }
+                                      # az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
+                                      # if ($? -eq $false) {
+                                      #   throw 'Failed to  delete-batch on storage account'
+                                      # }
+                                      # az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
+                                      # if ($? -eq $false) {
+                                      #   throw 'Failed to  upload-batch on storage account'
+                                      # }
 
-                                      $FWTest = $true
                                       write-output "Storage is now accessible & and data is uploaded"
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
                                         cdnHostNameStripped=${cdnHostName#https://}
+                                        echo "The value of cdnHostName is: $cdnHostName"
+                                        echo "The value of cdnHostNameStripped is: $cdnHostNameStripped"
                                         
                                         az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $(cdnHostNameStripped) --content-paths /* --debug
 
-                                        if($env:newCdnV){
-                                          $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
-                                          $cdnAssetsVersion = [decimal]$cdnAssetsVersion
-                                          $newCdnAssetsVersion = $cdnAssetsVersion+0.1
-                                          az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
-                                        }
+                                        # if($env:newCdnV){
+                                        #   $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
+                                        #   $cdnAssetsVersion = [decimal]$cdnAssetsVersion
+                                        #   $newCdnAssetsVersion = $cdnAssetsVersion+0.1
+                                        #   az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
+                                        # }
                                       }
 
                                       exit 0

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -166,6 +166,7 @@ stages:
                               Write-Host "Public Ip : $publicIp "
                               az storage account network-rule add --ip-address $publicIp --resource-group $(ShdResourceGroupName) --account-name $(storageAccountName)
                               Write-Host "##vso[task.setvariable variable=agentIp]$publicIp"
+                              Start-Sleep -Seconds 20
 
                         - task: AzureCLI@2
                           displayName: "Empty, upload & Purge Storage & CDN Contents & Updated CDN Version  "
@@ -182,7 +183,7 @@ stages:
                               
                               $FWTestAttempt = 1
                               $FWTestMax = 10
-                              Start-Sleep -Seconds 10
+                              
                               do {
                                   try {
                                       write-output "Removing files from storage account"
@@ -204,14 +205,14 @@ stages:
                                       if ($FWTestAttempt -lt $FWTestMax) {
                                           write-output "An error occurred during adding or removing files in storage account. $FWTestAttempt/$FWTestMax"
                                           $FWTestAttempt++
-                                          Start-Sleep -Seconds 20
+                                          Start-Sleep -Seconds 10
                                       }
                                       else {
                                           Write-Error "Max retries reached"
                                           exit 1
                                       }
                                   }
-                              } while ($FWTestAttempt -lt $FWTestMax)
+                              } while ($FWTestAttempt -le $FWTestMax)
 
                               if($ShdResourceGroupName -NotLike '*neu*'){
                                 $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -179,7 +179,7 @@ stages:
                             ${{ if not(parameters.shaUse) }}:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
-                              $ErrorActionPreference = "Stop"
+                              #$ErrorActionPreference = "Stop"
                               # write-output "Waiting for FW rule to apply."
 
                               # $FWTestAttempt = 1
@@ -201,10 +201,10 @@ stages:
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
                                         $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
-                                        echo "The value of cdnHostName is: $cdnHostName"
+                                        echo "The value of cdnHostName is: $env:cdnHostName"
                                         echo "The value of cdnHostNameStripped is: $cdnHostNameStripped"
                                         
-                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $(cdnHostNameStripped) --content-paths /* --debug
+                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --debug
 
                                         # if($env:newCdnV){
                                         #   $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -151,7 +151,7 @@ stages:
                           inputs:
                             azureSubscription: $(${{variables.ServConName}})
                             KeyVaultName: '$(keyVaultName)'
-                            SecretsFilter: '*'
+                            SecretsFilter: 'cdnHostName'
                             RunAsPreJob: false
                         
                         - task: AzureCLI@2

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -179,50 +179,50 @@ stages:
                             ${{ if not(parameters.shaUse) }}:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
-                              $ErrorActionPreference = "Stop"
-                              write-output "Waiting for FW rule to apply."
+                              #$ErrorActionPreference = "Stop"
+                              # write-output "Waiting for FW rule to apply."
 
-                              $FWTestAttempt = 1
-                              $FWTestMax = 25
-                              Start-Sleep -Seconds 35
-                              do {
-                                  try {
-                                      az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
-                                      if ($? -eq $false) {
-                                        throw 'Failed to  delete-batch on storage account'
-                                      }
-                                      az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
-                                      if ($? -eq $false) {
-                                        throw 'Failed to  upload-batch on storage account'
-                                      }
+                              # $FWTestAttempt = 1
+                              # $FWTestMax = 25
+                              # Start-Sleep -Seconds 35
+                              # do {
+                              #     try {
+                                      # az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
+                                      # if ($? -eq $false) {
+                                      #   throw 'Failed to  delete-batch on storage account'
+                                      # }
+                                      # az storage blob upload-batch  --account-name $(storageAccountName) --source  $(System.DefaultWorkingDirectory)/login.dfe.ui-toolkit/dist --destination $(UIContainerName) --auth-mode=login
+                                      # if ($? -eq $false) {
+                                      #   throw 'Failed to  upload-batch on storage account'
+                                      # }
 
-                                      write-output "Storage is now accessible & and data is uploaded"
+                                      # write-output "Storage is now accessible & and data is uploaded"
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
                                         az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $cdnHostNameStripped --content-paths /* --verbose
 
-                                        if($env:newCdnV){
-                                          $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
-                                          $cdnAssetsVersion = [decimal]$cdnAssetsVersion
-                                          $newCdnAssetsVersion = $cdnAssetsVersion+0.1
-                                          az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
-                                        }
+                                        # if($env:newCdnV){
+                                        #   $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value
+                                        #   $cdnAssetsVersion = [decimal]$cdnAssetsVersion
+                                        #   $newCdnAssetsVersion = $cdnAssetsVersion+0.1
+                                        #   az keyvault secret set --name cdnAssetsVersion --vault-name $(keyVaultName) --value $newCdnAssetsVersion
+                                        # }
                                       }
 
-                                      exit 0
-                                  }
-                                  catch {
-                                      if ($FWTestAttempt -lt $FWTestMax) {
-                                          write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
-                                          $FWTestAttempt++
-                                          Start-Sleep -Seconds 20
-                                      }
-                                      else {
-                                          Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
-                                      }
-                                  }
-                              } while ($FWTestAttempt -lt $FWTestMax)
+                              #         exit 0
+                              #     }
+                              #     catch {
+                              #         if ($FWTestAttempt -lt $FWTestMax) {
+                              #             write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
+                              #             $FWTestAttempt++
+                              #             Start-Sleep -Seconds 20
+                              #         }
+                              #         else {
+                              #             Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
+                              #         }
+                              #     }
+                              # } while ($FWTestAttempt -lt $FWTestMax)
 
                         - task: AzureCLI@2
                           displayName: Remove White-list of storage

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -199,7 +199,7 @@ stages:
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
-                                        cdnHostNameStripped=${cdnHostName#https://}
+                                        $cdnHostNameStripped=${cdnHostName#https://}
                                         echo "The value of cdnHostName is: $cdnHostName"
                                         echo "The value of cdnHostNameStripped is: $cdnHostNameStripped"
                                         

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -201,12 +201,12 @@ stages:
                                   }
                                   catch {
                                       if ($FWTestAttempt -lt $FWTestMax) {
-                                          write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
+                                          write-output "An error occurred during adding or removing files in storage account. $FWTestAttempt/$FWTestMax"
                                           $FWTestAttempt++
                                           Start-Sleep -Seconds 20
                                       }
                                       else {
-                                          Write-Error "An error occurred during adding or removing files in storage account. $FWTestAttempt/$FWTestMax."
+                                          Write-Error "Max retries reached"
                                       }
                                   }
                               } while ($FWTestAttempt -lt $FWTestMax)

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -108,10 +108,12 @@ stages:
                 value: $(SubShortName)-$(secRegionId)shd
               - name: UIContainerName
                 value: ui-assets
-              - name: azureCdnName
-                value: $(SubShortName)-signin-shd-cdn
-              - name: cdnEndpointName
-                value: $(SubShortName)-signin-shd-cdnep
+              - name: frontDoorCdnResourceGroupName
+                value: $(SubShortName)-fd
+              - name: frontDoorCdnProfileName
+                value: $(SubShortName)-signin-fd
+              - name: frontDoorCdnEndpointName
+                value: $(SubShortName)-signin
               - name: keyVaultName
                 value: $(SubShortName)-signin-kv
               - name: keyVaultResourceGroupName
@@ -189,7 +191,8 @@ stages:
                                       write-output "Storage is now accessible & and data is uploaded"
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
-                                        az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
+                                        #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
+                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --content-paths /* --debug #--domains www.contoso.com
 
                                         if($env:newCdnV){
                                           $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -179,13 +179,13 @@ stages:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
                               $ErrorActionPreference = "Stop"
-                              write-output "Waiting for FW rule to apply."
+                              # write-output "Waiting for FW rule to apply."
 
-                              $FWTestAttempt = 1
-                              $FWTestMax = 25
-                              Start-Sleep -Seconds 35
-                              do {
-                                  try {
+                              # $FWTestAttempt = 1
+                              # $FWTestMax = 25
+                              # Start-Sleep -Seconds 35
+                              # do {
+                              #     try {
                                       # az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
                                       # if ($? -eq $false) {
                                       #   throw 'Failed to  delete-batch on storage account'
@@ -195,7 +195,7 @@ stages:
                                       #   throw 'Failed to  upload-batch on storage account'
                                       # }
 
-                                      write-output "Storage is now accessible & and data is uploaded"
+                                      # write-output "Storage is now accessible & and data is uploaded"
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
@@ -213,19 +213,19 @@ stages:
                                         # }
                                       }
 
-                                      exit 0
-                                  }
-                                  catch {
-                                      if ($FWTestAttempt -lt $FWTestMax) {
-                                          write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
-                                          $FWTestAttempt++
-                                          Start-Sleep -Seconds 20
-                                      }
-                                      else {
-                                          Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
-                                      }
-                                  }
-                              } while ($FWTestAttempt -lt $FWTestMax)
+                              #         exit 0
+                              #     }
+                              #     catch {
+                              #         if ($FWTestAttempt -lt $FWTestMax) {
+                              #             write-output "Unable to access storage account $FWTestAttempt/$FWTestMax. Waiting for FW rule to take effect."
+                              #             $FWTestAttempt++
+                              #             Start-Sleep -Seconds 20
+                              #         }
+                              #         else {
+                              #             Write-Error "Unable to access storage account $FWTestAttempt/$FWTestMax."
+                              #         }
+                              #     }
+                              # } while ($FWTestAttempt -lt $FWTestMax)
 
                         - task: AzureCLI@2
                           displayName: Remove White-list of storage

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -171,6 +171,7 @@ stages:
                           displayName: "Empty, upload & Purge Storage & CDN Contents & Updated CDN Version  "
                           env:
                             newCdnV: ${{ parameters.cdn }}
+                            cdnHostName: $(cdnHostName)
                           inputs:
                             azureSubscription: $(${{variables.ServConName}})
                             scriptType: pscore
@@ -199,7 +200,7 @@ stages:
 
                                       if($ShdResourceGroupName -NotLike '*neu*'){
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
-                                        $cdnHostNameStripped=${cdnHostName#https://}
+                                        $cdnHostNameStripped = $env:cdnHostName -replace 'https://', ''
                                         echo "The value of cdnHostName is: $cdnHostName"
                                         echo "The value of cdnHostNameStripped is: $cdnHostNameStripped"
                                         

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -61,7 +61,7 @@ variables:
   - group: dsi-global
   - group: dsi-envs-list
   - name: tran
-    value: ${{ eq(parameters.tran, 'true') }}
+    value: ${{ eq(parameters.tran, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
   - name: dev
     value: ${{ or(eq(parameters.dev, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
   - name: test
@@ -202,7 +202,7 @@ stages:
                                         #az cdn endpoint purge --content-paths /* --profile-name $(azureCdnName) -g $(ShdResourceGroupName) -n $(cdnEndpointName)
                                         cdnHostNameStripped=${cdnHostName#https://}
                                         
-                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $(cdnHostNameStripped) --content-paths /*
+                                        az afd endpoint purge --resource-group $(frontDoorCdnResourceGroupName) --profile-name $(frontDoorCdnProfileName) --endpoint-name $(frontDoorCdnEndpointName) --domains $(cdnHostNameStripped) --content-paths /* --debug
 
                                         if($env:newCdnV){
                                           $cdnAssetsVersion = $(az keyvault secret show -n cdnAssetsVersion --vault-name $(keyVaultName)).value

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -61,7 +61,7 @@ variables:
   - group: dsi-global
   - group: dsi-envs-list
   - name: tran
-    value: ${{ eq(parameters.tran, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
+    value: ${{ or(eq(parameters.tran, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
   - name: dev
     value: ${{ or(eq(parameters.dev, 'true'), contains(variables['Build.SourceBranch'],'feature')) }}
   - name: test

--- a/DevOps/pipeline/azure-pipeline.yml
+++ b/DevOps/pipeline/azure-pipeline.yml
@@ -179,6 +179,7 @@ stages:
                             ${{ if not(parameters.shaUse) }}:
                               workingDirectory: $(System.DefaultWorkingDirectory)
                             inlineScript: |
+                              
                               $FWTestAttempt = 1
                               $FWTestMax = 10
                               Start-Sleep -Seconds 10
@@ -186,7 +187,7 @@ stages:
                                   try {
                                       write-output "Removing files from storage account"
 
-                                      az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --only-show-errors --auth-mode=login
+                                      az storage blob delete-batch --account-name $(storageAccountName) --source $(UIContainerName) --auth-mode=login
                                       if ($? -eq $false) {
                                         throw 'Failed to  delete-batch on storage account'
                                       }
@@ -207,6 +208,7 @@ stages:
                                       }
                                       else {
                                           Write-Error "Max retries reached"
+                                          exit 1
                                       }
                                   }
                               } while ($FWTestAttempt -lt $FWTestMax)


### PR DESCRIPTION
- Added params for new CDN, removed params for old CDN
- Added step to get secrets from keyvault to get cdnHostName
- Purge step modified to apply to new CDN
- Additional logging for clarity
- Reworked retry loop to have more retried but with less time between them. Also fixed loop not exiting properly.