### PR TITLE
[DSI-7687] Add security headers when running locally.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "govuk_template_jinja": "^0.26.0",
         "govuk-elements-sass": "^3.1.2",
         "govuk-frontend": "^5.9.0",
+        "helmet": "^8.1.0",
         "jquery": "^3.6.0",
         "js-cookie": "^3.0.1",
         "nunjucks": "^3.2.0"
@@ -3674,6 +3675,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha1-+W0j/tyJ6Uduy1GYGBAJyAS4s4w=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/hmac-drbg": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "govuk_template_jinja": "^0.26.0",
     "govuk-elements-sass": "^3.1.2",
     "govuk-frontend": "^5.9.0",
+    "helmet": "^8.1.0",
     "jquery": "^3.6.0",
     "js-cookie": "^3.0.1",
     "nunjucks": "^3.2.0"

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const nunjucks = require("nunjucks");
 const express = require("express");
 const cors = require("cors");
+const helmet = require("helmet");
 
 const routes = require("./app/routes");
 
@@ -24,10 +25,28 @@ nunjucks.configure("app/gds-upgrade/views", {
   noCache: true,
 });
 
+app.use(cors({ origin: "*" }));
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'", "localhost:*"],
+      },
+    },
+    crossOriginOpenerPolicy: {
+      policy: "same-origin",
+    },
+    crossOriginResourcePolicy: {
+      policy: "cross-origin",
+    },
+  }),
+);
+
 app.set("view engine", "html");
-app.use("/", cors(), express.static("dist/"));
-app.use("/static", cors(), express.static("dist/"));
-app.use("/gds-upgrade", cors(), express.static("dist/gds-upgrade/"));
+app.use("/", express.static("dist/"));
+app.use("/static", express.static("dist/"));
+app.use("/gds-upgrade", express.static("dist/gds-upgrade/"));
 
 routes.bind(app);
 


### PR DESCRIPTION
This PR introduces security headers when running scripts and styles locally to provide developers with a similar experience in localhost as to what would be experienced in a hosted environment.